### PR TITLE
Add :closure-defines to compiler options

### DIFF
--- a/src/duct/module/cljs.clj
+++ b/src/duct/module/cljs.clj
@@ -29,6 +29,7 @@
        :output-to  (str path "/js/main.js")
        :output-dir (str path "/js")
        :asset-path "/js"
+       :closure-defines {'goog.DEBUG false}
        :verbose    true
        :optimizations :advanced}}]}})
 
@@ -44,6 +45,7 @@
        :output-to  (str path "/js/main.js")
        :output-dir (str path "/js")
        :asset-path "/js"
+       :closure-defines {'goog.DEBUG true}
        :verbose    false
        :preloads   '[devtools.preload]
        :optimizations :none}}]}})

--- a/test/duct/module/cljs_test.clj
+++ b/test/duct/module/cljs_test.clj
@@ -24,6 +24,7 @@
                        :output-to  (absolute-path "target/resources/foo/public/js/main.js")
                        :output-dir (absolute-path "target/resources/foo/public/js")
                        :asset-path "/js"
+                       :closure-defines {'goog.DEBUG false}
                        :verbose    true
                        :optimizations :advanced}}]}}))))
 
@@ -42,6 +43,7 @@
                        :output-to  (absolute-path "target/resources/foo/public/js/main.js")
                        :output-dir (absolute-path "target/resources/foo/public/js")
                        :asset-path "/js"
+                       :closure-defines {'goog.DEBUG true}
                        :verbose    false
                        :preloads   ['devtools.preload]
                        :optimizations :none}}]}}))))))


### PR DESCRIPTION
By adding the `:closure-defines` option and setting `goog.DEBUG` to `false`, the compiler can eliminate unwanted dev code at compile time.