### PR TITLE
Add Service Worker support to module.cljs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,8 @@ pom.xml.asc
 /.nrepl-port
 .hgignore
 .hg/
+/.idea/
+*.idea
+.idea
+*.iml
+.iml

--- a/project.clj
+++ b/project.clj
@@ -7,7 +7,6 @@
                  [org.clojure/clojurescript "1.10.238"]
                  [binaryage/devtools "0.9.7"]
                  [duct/core "0.6.1"]
-                 [hireling "0.6.0"]
                  [duct/compiler.cljs "0.2.0"]
                  [duct/server.figwheel "0.2.1"]
                  [integrant "0.6.1"]])

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject zaphodious/module.cljs "0.4.0-SNAPSHOT"
+(defproject duct/module.cljs "0.4.0"
   :description "Duct module for developing and compiling ClojureScript"
   :url "https://github.com/duct-framework/module.cljs"
   :license {:name "Eclipse Public License"
@@ -7,7 +7,7 @@
                  [org.clojure/clojurescript "1.10.238"]
                  [binaryage/devtools "0.9.7"]
                  [duct/core "0.6.1"]
-                 [hireling "0.6.0-ALPHA-SNAPSHOT"]
+                 [hireling "0.6.0"]
                  [duct/compiler.cljs "0.2.0"]
                  [duct/server.figwheel "0.2.1"]
                  [integrant "0.6.1"]])

--- a/project.clj
+++ b/project.clj
@@ -1,12 +1,13 @@
-(defproject duct/module.cljs "0.3.2"
+(defproject zaphodious/module.cljs "0.4.0-SNAPSHOT"
   :description "Duct module for developing and compiling ClojureScript"
   :url "https://github.com/duct-framework/module.cljs"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.9.0-RC2"]
-                 [org.clojure/clojurescript "1.9.946"]
+  :dependencies [[org.clojure/clojure "1.9.0"]
+                 [org.clojure/clojurescript "1.10.238"]
                  [binaryage/devtools "0.9.7"]
                  [duct/core "0.6.1"]
+                 [hireling "0.6.0-ALPHA-SNAPSHOT"]
                  [duct/compiler.cljs "0.2.0"]
                  [duct/server.figwheel "0.2.1"]
                  [integrant "0.6.1"]])

--- a/src/duct/module/cljs.clj
+++ b/src/duct/module/cljs.clj
@@ -26,12 +26,14 @@
         :source-paths ["src"]
         :build-options
         {:main sw-main
-         :output-to (src path "/sw.js")
-         :output-dir (src path "/sw")
+         :output-to (str path "/sw.js")
+         :output-dir (str path "/sw")
          :asset-path "/sw"
          :closure-defines {'goog.DEBUG false}
          :verbose true
          :infer-externs true
+         :language-in :es6
+         :rewrite-polyfills true
          :optimizations :advanced
          :target :webworker}})
      {:source-paths  ["src"]
@@ -59,6 +61,8 @@
        :closure-defines {'goog.DEBUG true}
        :verbose    false
        :infer-externs true
+       :language-in :es6
+       :rewrite-polyfills true
        :preloads   '[devtools.preload]
        :optimizations :none
        :target :webworker}}

--- a/src/duct/module/cljs.clj
+++ b/src/duct/module/cljs.clj
@@ -21,51 +21,52 @@
 (defn- compiler-config [path main sw-main]
   {:duct.compiler/cljs
    {:builds ^:displace
-    [(when sw-main
-       {:id "sw"
-        :source-paths ["src"]
-        :build-options
-        {:main sw-main
-         :output-to (str path "/sw.js")
-         :output-dir (str path "/sw")
-         :asset-path "/sw"
-         :closure-defines {'goog.DEBUG false}
-         :verbose true
-         :infer-externs true
-         :language-in :es6
-         :rewrite-polyfills true
-         :optimizations :advanced
-         :target :webworker}})
-     {:source-paths  ["src"]
-      :build-options
-      {:main       main
-       :output-to  (str path "/js/main.js")
-       :output-dir (str path "/js")
-       :asset-path "/js"
-       :closure-defines {'goog.DEBUG false}
-       :verbose    true
-       :optimizations :advanced}}]}})
+            [(when sw-main
+               {:id           "sw"
+                :source-paths ["src"]
+                :build-options
+                              {:main              sw-main
+                               :output-to         (str path "/sw.js")
+                               :output-dir        (str path "/sw")
+                               :asset-path        "/sw"
+                               :closure-defines   {'goog.DEBUG false}
+                               :verbose           true
+                               :infer-externs     true
+                               :language-in       :es6
+                               :rewrite-polyfills true
+                               :optimizations     :advanced
+                               :target            :webworker}})
+             {:source-paths ["src"]
+              :build-options
+                            {:main            main
+                             :output-to       (str path "/js/main.js")
+                             :output-dir      (str path "/js")
+                             :asset-path      "/js"
+                             :closure-defines {'goog.DEBUG false}
+                             :verbose         true
+                             :optimizations   :advanced}}]}})
 
 (defn- figwheel-config [path main sw-main]
   {:duct.server/figwheel
    {:css-dirs ^:displace ["resources" "dev/resources"]
     :builds   ^:displace
-    [{:id "sw-dev"
-      :figwheel false
-      :source-paths ["dev/src" "src"]
-      :build-options
-      {:main       sw-main
-       :output-to  (str path "/sw.js")
-       :output-dir (str path "/sw")
-       :asset-path "/sw"
-       :closure-defines {'goog.DEBUG true}
-       :verbose    false
-       :infer-externs true
-       :language-in :es6
-       :rewrite-polyfills true
-       :preloads   '[devtools.preload]
-       :optimizations :none
-       :target :webworker}}
+    [(when sw-main
+       {:id "sw-dev"
+        :figwheel false
+        :source-paths ["dev/src" "src"]
+        :build-options
+        {:main       sw-main
+         :output-to  (str path "/sw.js")
+         :output-dir (str path "/sw")
+         :asset-path "/sw"
+         :closure-defines {'goog.DEBUG true}
+         :verbose    false
+         :infer-externs true
+         :language-in :es6
+         :rewrite-polyfills true
+         :preloads   '[devtools.preload]
+         :optimizations :none
+         :target :webworker}})
      {:id           "dev"
       :figwheel     true
       :source-paths ["dev/src" "src"]

--- a/test/duct/module/cljs_test.clj
+++ b/test/duct/module/cljs_test.clj
@@ -50,7 +50,7 @@
                        :optimizations :advanced}}]}}))))
 
   (testing "development config"
-    (let [config (assoc base-config ::core/environment :development)]
+    (let [config (assoc service-worker-base-config ::core/environment :development)]
       (is (= (core/prep config)
            (merge config
                   {:duct.server/figwheel

--- a/test/duct/module/cljs_test.clj
+++ b/test/duct/module/cljs_test.clj
@@ -9,7 +9,8 @@
 
 (def base-config
   {:duct.core/project-ns 'foo
-   :duct.module/cljs     {:main 'foo.client}})
+   :duct.module/cljs     {:main 'foo.client
+                          :sw-main 'foo.sw}})
 
 (defn- absolute-path [relative-path]
   (.getAbsolutePath (io/file relative-path)))
@@ -20,7 +21,21 @@
            (merge base-config
                   {:duct.compiler/cljs
                    {:builds
-                    [{:source-paths ["src"]
+                    [{:id "sw"
+                      :source-paths ["src"]
+                      :build-options
+                      {:main 'foo.sw
+                       :output-to   (absolute-path "target/resources/foo/public/sw.js")
+                       :output-dir (absolute-path "target/resources/foo/public/sw")
+                       :asset-path "/sw"
+                       :closure-defines {'goog.DEBUG false}
+                       :verbose true
+                       :infer-externs true
+                       :language-in :es6
+                       :rewrite-polyfills true
+                       :optimizations :advanced
+                       :target :webworker}}
+                     {:source-paths ["src"]
                       :build-options
                       {:main       'foo.client
                        :output-to  (absolute-path "target/resources/foo/public/js/main.js")
@@ -37,7 +52,23 @@
                   {:duct.server/figwheel
                    {:css-dirs ["resources" "dev/resources"]
                     :builds
-                    [{:id           "dev"
+                    [{:id "sw-dev"
+                      :figwheel false
+                      :source-paths ["dev/src" "src"]
+                      :build-options
+                      {:main       'foo.sw
+                       :output-to   (absolute-path "target/resources/foo/public/sw.js")
+                       :output-dir (absolute-path "target/resources/foo/public/sw")
+                       :asset-path "/sw"
+                       :closure-defines {'goog.DEBUG true}
+                       :verbose    false
+                       :infer-externs true
+                       :language-in :es6
+                       :rewrite-polyfills true
+                       :preloads   '[devtools.preload]
+                       :optimizations :none
+                       :target :webworker}}
+                     {:id           "dev"
                       :figwheel     true
                       :source-paths ["dev/src" "src"]
                       :build-options

--- a/test/duct/module/cljs_test.clj
+++ b/test/duct/module/cljs_test.clj
@@ -20,7 +20,7 @@
   (.getAbsolutePath (io/file relative-path)))
 
 (deftest service-worker-module-test
-  (testing "production config"
+  (testing "production config with service worker"
     (is (= (core/prep service-worker-base-config)
            (merge service-worker-base-config
                   {:duct.compiler/cljs
@@ -49,7 +49,7 @@
                        :verbose    true
                        :optimizations :advanced}}]}}))))
 
-  (testing "development config"
+  (testing "development config with service worker"
     (let [config (assoc service-worker-base-config ::core/environment :development)]
       (is (= (core/prep config)
            (merge config
@@ -86,7 +86,7 @@
                        :optimizations :none}}]}}))))))
 
 (deftest module-test
-  (testing "production config"
+  (testing "production config without service worker"
     (is (= (core/prep base-config)
            (merge base-config
                   {:duct.compiler/cljs
@@ -102,7 +102,7 @@
                                      :verbose    true
                                      :optimizations :advanced}}]}}))))
 
-  (testing "development config"
+  (testing "development config without service worker"
     (let [config (assoc base-config ::core/environment :development)]
       (is (= (core/prep config)
              (merge config

--- a/test/duct/module/cljs_test.clj
+++ b/test/duct/module/cljs_test.clj
@@ -91,7 +91,8 @@
            (merge base-config
                   {:duct.compiler/cljs
                    {:builds
-                    [{:source-paths ["src"]
+                    [nil
+                     {:source-paths ["src"]
                       :build-options
                                     {:main       'foo.client
                                      :output-to  (absolute-path "target/resources/foo/public/js/main.js")
@@ -108,7 +109,8 @@
                     {:duct.server/figwheel
                      {:css-dirs ["resources" "dev/resources"]
                       :builds
-                                [{:id           "dev"
+                                [nil
+                                 {:id           "dev"
                                   :figwheel     true
                                   :source-paths ["dev/src" "src"]
                                   :build-options


### PR DESCRIPTION
Add support for service worker compilation. Clojurescript dependency bumped to 1.10 to allow for `:target :webworker`. Separate compiler opts map used for dev and production, with options conducive to service worker development and use. Of special note is `:language-in :es6, :rewrite-polyfills true` due to service workers requiring the use of js promises, `:output-to (str path "/sw.js")` due to service workers needing to be served from the same directory as the site they control, and `:infer-externs true` to assist with development as obscure closure errors are hard to debug when figwheel isn't a thing. (Externs inference is kept for deployment due to the negative impact being either compile-time-only when enabled, or potentially breaking when dev and prod have this set differently). Also of note is that this change is independent of figwheel, as the duct workflow refreshes the service worker file on `(reset)` (which can then be updated in whatever way required by the browser being used).

As a result of this pull request, adding service worker support to a project is as easy as creating a new cljs namespace and pointing module.cljs to it, like so- `:duct.module/cljs {:sw-main project-name.sw}`